### PR TITLE
handle breaking change introduced in httpx 0.28.0

### DIFF
--- a/gamla/io_utils.py
+++ b/gamla/io_utils.py
@@ -310,13 +310,13 @@ async def post_json_with_extra_headers_and_params_async(
 #: Expects the payload to be a json serializable object and the headers to be a dictionary.
 #:
 #: >>> response = post_json_with_extra_headers_async({"username": "First Last", 30, "https://www.someurl.com/post_data", { "name": "Danny" })
-post_json_with_extra_headers_async = post_json_with_extra_headers_and_params_async({})
+post_json_with_extra_headers_async = post_json_with_extra_headers_and_params_async(None)
 
 #: Performs an http POST request of json data.
 #: Expects the payload to be a json serializable object.
 #:
 #: >>> response = post_json_async(30, "https://www.someurl.com/post_data", { "name": "Danny" })
-post_json_async = post_json_with_extra_headers_and_params_async({}, {})
+post_json_async = post_json_with_extra_headers_and_params_async(None, {})
 
 
 @currying.curry

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="gamla",
-    version="157",
+    version="158",
     python_requires=">=3.11",
     long_description=_LONG_DESCRIPTION,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
A recent update to the httpx library, version 0.28.0, introduced a breaking change in how it handles URL query parameters. Code that previously worked by providing parameters in both the params and the kwargs will now fail. This patch resolves the issue by consolidating all parameters into the kwargs.

Further reading: https://github.com/encode/httpx/issues/3433