### PR TITLE
handle breaking change introduced in httpx 0.28.0

### DIFF
--- a/gamla/io_utils.py
+++ b/gamla/io_utils.py
@@ -260,12 +260,12 @@ async def get_async_with_headers_and_params(
 #: Performs an async GET request to url with the specified timeout (seconds) and headers.
 #:
 #: >>> response = await get_async_with_headers({some_header: some_value}, 30, "https://www.someurl.com")
-get_async_with_headers = get_async_with_headers_and_params({})
+get_async_with_headers = get_async_with_headers_and_params(None)
 
 #: Performs an async GET request to url with the specified timeout.
 #:
 #: >>> response = await get_async(30, "https://www.someurl.com")
-get_async = get_async_with_headers_and_params({}, {})
+get_async = get_async_with_headers_and_params(None, {})
 
 
 @currying.curry


### PR DESCRIPTION
A recent update to the httpx library, version 0.28.0, introduced a breaking change in how it handles URL query parameters. Code that previously worked by providing parameters in both the params and the kwargs will now fail. This patch resolves the issue by consolidating all parameters into the kwargs.

Further reading: https://github.com/encode/httpx/issues/3433