### PR TITLE
Cache frozendict hash

### DIFF
--- a/gamla/data.py
+++ b/gamla/data.py
@@ -19,7 +19,15 @@ class frozendict(dict):  # noqa: N801
         super(frozendict, self).__init__(*args, **kwargs)
 
     def __hash__(self):
-        return hash(tuple(self.items()))
+        # frozendict is immutable, so cache the hash on first use: instances are
+        # re-hashed many times (set/dict membership) and recomputing recurses
+        # through nested frozendicts. Stored in __dict__ directly to bypass the
+        # _immutable guard; it is not part of the dict items.
+        cached = self.__dict__.get("_cached_hash")
+        if cached is None:
+            cached = hash(tuple(self.items()))
+            self.__dict__["_cached_hash"] = cached
+        return cached
 
     def __gt__(self, other):
         return functional_generic.map_dict(dict.items, operator.identity)(

--- a/gamla/data.py
+++ b/gamla/data.py
@@ -1,4 +1,5 @@
 import dataclasses
+import functools
 import itertools
 import json
 from typing import Any, Callable, Collection, Dict
@@ -18,16 +19,19 @@ class frozendict(dict):  # noqa: N801
         self.__setattr__ = _immutable
         super(frozendict, self).__init__(*args, **kwargs)
 
+    @functools.cached_property
+    def _hash(self):
+        # Caching matters: a frozendict is re-hashed heavily (set/dict membership
+        # during graph composition) and each recompute recurses through nested
+        # frozendicts. cached_property fills __dict__ lazily on first access, so it
+        # neither runs at construction (values may be unhashable yet never hashed)
+        # nor goes stale when dill/pickle repopulates items after construction.
+        return hash(tuple(self.items()))
+
     def __hash__(self):
-        # frozendict is immutable, so cache the hash on first use: instances are
-        # re-hashed many times (set/dict membership) and recomputing recurses
-        # through nested frozendicts. Stored in __dict__ directly to bypass the
-        # _immutable guard; it is not part of the dict items.
-        cached = self.__dict__.get("_cached_hash")
-        if cached is None:
-            cached = hash(tuple(self.items()))
-            self.__dict__["_cached_hash"] = cached
-        return cached
+        # hash() looks __hash__ up on the type and calls it, so __hash__ itself
+        # can't be the cached_property — delegate to the cached helper.
+        return self._hash
 
     def __gt__(self, other):
         return functional_generic.map_dict(dict.items, operator.identity)(

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="gamla",
-    version="159",
+    version="160",
     python_requires=">=3.11",
     long_description=_LONG_DESCRIPTION,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Summary
`gamla.frozendict.__hash__` recomputed `hash(tuple(self.items()))` on every call, recursing through nested frozendicts. Profiling a healthcare agent build showed frozendict instances get re-hashed ~10× each (the *same* objects — ~177k instances, ~1.1 instances/value, so not content duplication), making hashing a top build cost. This caches the hash lazily on the instance — a pure cache (the value is byte-identical to before).

Impact: ~23–34% faster agent build