### PR TITLE
CORE-32: use inspect.iscoroutinefunction (asyncio.iscoroutinefunction deprecated in 3.14)

### DIFF
--- a/gamla/currying.py
+++ b/gamla/currying.py
@@ -1,4 +1,3 @@
-import asyncio
 import functools
 import inspect
 
@@ -97,7 +96,7 @@ def curry(f):
         len(f_len_args) > 1
     ), f"Curry function must have at least 2 parameters, {f} has {len(f_len_args)}"
     defaults = _infer_defaults(f_len_args)
-    is_coroutine = asyncio.iscoroutinefunction(f)
+    is_coroutine = inspect.iscoroutinefunction(f)
 
     @functools.wraps(f)
     def indirection(*args, **kwargs):

--- a/gamla/debug_utils.py
+++ b/gamla/debug_utils.py
@@ -1,6 +1,6 @@
-import asyncio
 import builtins
 import functools
+import inspect
 import logging
 from typing import Text
 
@@ -105,7 +105,7 @@ def _print_stats():
 
 
 def profileit(f):
-    if asyncio.iscoroutinefunction(f):
+    if inspect.iscoroutinefunction(f):
 
         @functools.wraps(f)
         async def wrapper(*args, **kwargs):

--- a/gamla/excepts_decorator.py
+++ b/gamla/excepts_decorator.py
@@ -1,5 +1,5 @@
-import asyncio
 import functools
+import inspect
 from typing import Any, Callable, Tuple, Union
 
 from gamla import currying
@@ -11,7 +11,7 @@ def excepts(
     handler: Callable[[Exception], Any],
     function: Callable,
 ):
-    if asyncio.iscoroutinefunction(function):
+    if inspect.iscoroutinefunction(function):
 
         async def excepts(*args, **kwargs):
             try:
@@ -36,7 +36,7 @@ def try_and_excepts(
     function: Callable,
 ):
     """Same as sync excepts only that the handler gets the original function params after the exception param."""
-    if asyncio.iscoroutinefunction(function):
+    if inspect.iscoroutinefunction(function):
 
         async def try_and_excepts(*args, **kwargs):
             try:

--- a/gamla/functional_generic.py
+++ b/gamla/functional_generic.py
@@ -51,6 +51,23 @@ def compose_left(*funcs):
     return compose(*reversed(funcs))
 
 
+_CO_COROUTINE = inspect.CO_COROUTINE
+_IS_COROUTINE_MARKER = getattr(asyncio.coroutines, "_is_coroutine", object())
+
+
+def _fast_iscoroutinefunction(f) -> bool:
+    """`asyncio.iscoroutinefunction` without the `inspect` machinery for the
+    common case of plain functions, which dominates composition-heavy code."""
+    while isinstance(f, functools.partial):
+        f = f.func
+    code = getattr(f, "__code__", None)
+    if code is None:
+        return asyncio.iscoroutinefunction(f)
+    return bool(code.co_flags & _CO_COROUTINE) or (
+        getattr(f, "_is_coroutine", None) is _IS_COROUTINE_MARKER
+    )
+
+
 def curried_map(f):
     """Constructs a function that maps elements of a given iterable using the given function.
 
@@ -60,7 +77,7 @@ def curried_map(f):
     >>> curried_map(inc)([3, 4, 5])
     [4, 5, 6]
     """
-    if asyncio.iscoroutinefunction(f):
+    if _fast_iscoroutinefunction(f):
         return async_functions.map(f)
     return sync.map(f)
 
@@ -83,7 +100,7 @@ def curried_to_binary(f):
 
 
 def any_is_async(funcs):
-    return any(map(asyncio.iscoroutinefunction, funcs))
+    return any(map(_fast_iscoroutinefunction, funcs))
 
 
 # Copying `toolz` convention.

--- a/gamla/functional_generic.py
+++ b/gamla/functional_generic.py
@@ -51,23 +51,6 @@ def compose_left(*funcs):
     return compose(*reversed(funcs))
 
 
-_CO_COROUTINE = inspect.CO_COROUTINE
-_IS_COROUTINE_MARKER = getattr(asyncio.coroutines, "_is_coroutine", object())
-
-
-def _fast_iscoroutinefunction(f) -> bool:
-    """`asyncio.iscoroutinefunction` without the `inspect` machinery for the
-    common case of plain functions, which dominates composition-heavy code."""
-    while isinstance(f, functools.partial):
-        f = f.func
-    code = getattr(f, "__code__", None)
-    if code is None:
-        return asyncio.iscoroutinefunction(f)
-    return bool(code.co_flags & _CO_COROUTINE) or (
-        getattr(f, "_is_coroutine", None) is _IS_COROUTINE_MARKER
-    )
-
-
 def curried_map(f):
     """Constructs a function that maps elements of a given iterable using the given function.
 
@@ -77,7 +60,7 @@ def curried_map(f):
     >>> curried_map(inc)([3, 4, 5])
     [4, 5, 6]
     """
-    if _fast_iscoroutinefunction(f):
+    if inspect.iscoroutinefunction(f):
         return async_functions.map(f)
     return sync.map(f)
 
@@ -100,7 +83,7 @@ def curried_to_binary(f):
 
 
 def any_is_async(funcs):
-    return any(map(_fast_iscoroutinefunction, funcs))
+    return any(map(inspect.iscoroutinefunction, funcs))
 
 
 # Copying `toolz` convention.
@@ -702,7 +685,7 @@ def reduce_curried(
     reducer: Reducer,
     initial_value: _ReducerState,
 ) -> Callable[[Iterable[_ReducedElement]], _ReducerState]:
-    if asyncio.iscoroutinefunction(reducer):
+    if inspect.iscoroutinefunction(reducer):
 
         async def reduce_async(elements):
             state = initial_value
@@ -723,7 +706,7 @@ def scan(
 
     See https://en.wikipedia.org/wiki/Prefix_sum#Scan_higher_order_function."""
 
-    if asyncio.iscoroutinefunction(reducer):
+    if inspect.iscoroutinefunction(reducer):
 
         async def reduce_keeping_history_async(
             past_states: Tuple[_ReducerState, ...],
@@ -800,7 +783,7 @@ map_filter_empty = compose_left(curried_map, after(curried_filter(operator.ident
 
 
 def merge_with(f):
-    if asyncio.iscoroutinefunction(f):
+    if inspect.iscoroutinefunction(f):
 
         async def merge_with(*dicts):
             result = _inner_merge_with(dicts)
@@ -860,7 +843,7 @@ def side_effect(f: Callable):
     2
     3
     """
-    if asyncio.iscoroutinefunction(f):
+    if inspect.iscoroutinefunction(f):
 
         async def do(x):
             if is_generator(x):

--- a/gamla/higher_order.py
+++ b/gamla/higher_order.py
@@ -1,4 +1,4 @@
-import asyncio
+import inspect
 from typing import Any, Callable
 
 from gamla import construct, excepts_decorator, functional, functional_generic, operator
@@ -47,7 +47,7 @@ def prepare_and_apply_async(f: Callable) -> Callable:
 
 def ignore_first_arg(f: Callable) -> Callable:
     """Ignores the first argument."""
-    if asyncio.iscoroutinefunction(f):
+    if inspect.iscoroutinefunction(f):
 
         async def ignore_first_arg_async(_, *args, **kwargs):
             return await f(*args, **kwargs)

--- a/gamla/io_utils.py
+++ b/gamla/io_utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import functools
+import inspect
 import logging
 import threading
 import time
@@ -59,7 +60,7 @@ def timeit_with_label(label: str, f: Callable) -> Callable:
             ":" + label
         )  # Do NOT change this format. We have datadog monitors dependent on it.
 
-    if asyncio.iscoroutinefunction(f):
+    if inspect.iscoroutinefunction(f):
         return _async_timeit(label, f)
 
     @functools.wraps(f)
@@ -182,7 +183,7 @@ def make_throttler(limit):
 
     def wrap_function(f):
 
-        if asyncio.iscoroutinefunction(f):
+        if inspect.iscoroutinefunction(f):
 
             @functools.wraps(f)
             async def wrap(*args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="gamla",
-    version="161",
+    version="162",
     python_requires=">=3.11",
     long_description=_LONG_DESCRIPTION,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Summary
Replaces every `asyncio.iscoroutinefunction` call site in gamla with `inspect.iscoroutinefunction` (any_is_async, curried_map, curry, excepts, timeit/retry, profileit, reducers, merge_with, side_effect).

`asyncio.iscoroutinefunction` is deprecated in Python 3.14 in favor of `inspect.iscoroutinefunction`, and the two are equivalent here — nothing in gamla, computation-graph, or nlu-runtime sets the `_is_coroutine` marker that asyncio additionally checks (verified by grep + exact output parity on every callable).